### PR TITLE
Don't pollute the library's namespace with the whole std::

### DIFF
--- a/wbExit.cpp
+++ b/wbExit.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 
 #include    <wb.h>
 
@@ -7,6 +8,8 @@ void wb_atExit(void) {
     cudaDeviceSynchronize();
 #endif /* WB_USE_CUDA */
 
+    using std::cout;
+    using std::endl;
 
     cout << "{\n"
          << wbString_quote("timer") << ":" << wbTimer_toJSON() << ",\n"

--- a/wbString.h
+++ b/wbString.h
@@ -12,7 +12,10 @@
 #include	<sstream>
 #include	<cstring>
 
-using namespace std;
+using std::string;
+using std::vector;
+using std::stringstream;
+using std::exception;
 
 template <typename T> static inline string wbString(const T & x);
 


### PR DESCRIPTION
As a library writer, one should refrain from `using namespace std;` in the headers. This will flood the library's namespace with all definitions from `std::` and facilitate name conflicts in **any program** doing `#include <wb.h>`.

We may hope, that _probably_ this will not cause any problems in the scope of the submission system; but it's still a [poor engineering practice](http://stackoverflow.com/questions/1452721/why-is-using-namespace-std-considered-bad-practice) and will inadvertently _teach_ bad habits to the users of the library — for no good reason.
