### PR TITLE
Fix to cmake lists (possibly)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,7 @@ if(CUDA_FOUND)
     # whether to build x64.  We tell it to support most devices, though, 
     # to make sure more people can easily run class code without knowing 
     # about this compiler argument
-    set(CUDA_NVCC_FLAGS "
-                            -gencode;arch=compute_20,code=sm_20; 
-                            -gencode;arch=compute_11,code=sm_11; 
-                            -gencode;arch=compute_12,code=sm_12;
-                            -gencode;arch=compute_13,code=sm_13;")
+    set(CUDA_NVCC_FLAGS "")
 
     # add -Wextra compiler flag for gcc compilations
     if (UNIX)


### PR DESCRIPTION
My problem was that cuda was not working (well I mean --- kernell call just wouldn't run) after a time I boiled it down to cryptic error: 

```
{
"level":"Error",
"message":"invalid device function cudaGetLastError()",
"file":"/home/.../libwb/skel/mp2.cu",
"function":"main",
"line":105,
"time":5665866836884
}
```

Which got me to a a udacity post that something is wrong with NVCC_OPTS, and that `nvcc` can guess all options by itself. 

I guess that these options had some reason to be specified, and removing it might not be an option, if so please add a line so my device is also covered (thus helping other people). 

Anyways my `deviceQuery` returns: 

```
Device 0: "Quadro K2000M"
  CUDA Driver Version / Runtime Version          5.5 / 4.2
  CUDA Capability Major/Minor version number:    3.0
  Total amount of global memory:                 2047 MBytes (2146762752 bytes)
  ( 2) Multiprocessors x (192) CUDA Cores/MP:    384 CUDA Cores
  GPU Clock rate:                                745 MHz (0.75 GHz)
  Memory Clock rate:                             900 Mhz
  Memory Bus Width:                              128-bit
  L2 Cache Size:                                 262144 bytes
  Max Texture Dimension Size (x,y,z)             1D=(65536), 2D=(65536,65536), 3D=(4096,4096,4096)
  Max Layered Texture Size (dim) x layers        1D=(16384) x 2048, 2D=(16384,16384) x 2048
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  2048
  Maximum number of threads per block:           1024
  Maximum sizes of each dimension of a block:    1024 x 1024 x 64
  Maximum sizes of each dimension of a grid:     2147483647 x 65535 x 65535
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 1 copy engine(s)
  Run time limit on kernels:                     Yes
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Disabled
  Device supports Unified Addressing (UVA):      Yes
  Device PCI Bus ID / PCI location ID:           1 / 0
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

```
