### PR TITLE
tackle issue that after wbCUDAMalloc call of cudaGetLastError() delivers 11 (invalid argument)

### DIFF
--- a/wbCUDA.h
+++ b/wbCUDA.h
@@ -1,3 +1,4 @@
+
 #ifndef __WB_CUDA_H__
 #define __WB_CUDA_H__
 
@@ -20,7 +21,7 @@ static inline cudaError_t wbCUDAMalloc(void **devPtr, size_t sz) {
   int idx = _cudaMemoryListIdx;
   cudaError_t err = cudaMalloc(devPtr, sz);
   if (err == cudaSuccess) {
-    cudaMemset(*devPtr, 0, sz);
+    err = cudaMemset(*devPtr, 0, sz);
   }
   if (idx == 0) {
     memset(_cudaMemoryList, 0, sizeof(wbCUDAMemory_t) * _cudaMemoryListSize);


### PR DESCRIPTION
I had wrapped my original cudaMalloc call with wbCheck which checks the err from line 22, but the cudaMemset from line 24 causes cudaGetLastError() to deliver 11 (invalid argument) which causes some trouble. Anyway, CUDA has probably not performed the line 24.
