### PR TITLE
Add support for running on a single dataset in runmp.sh

### DIFF
--- a/runmp.sh
+++ b/runmp.sh
@@ -1,10 +1,12 @@
-if [ $# -ne 1 ]
+if [ $# -eq 0 ]
 then
-    echo "usage: $0 <mp number>" 1>&2
+    echo "Usage: $0 <mp number> (<dataset number>)" 1>&2
+    echo "<dataset number> is optional, if not provided, the mp is executed on all datasets" 1>&2
     exit 1
 fi
 
 MP=$1
+DATASET=$2
 TARGET=build/Debug/MP${MP}.exe
 
 if [ ! -x ${TARGET} ]
@@ -37,7 +39,7 @@ case ${MP} in
         ;;
 esac
 
-for dataset in ${DATADIR}/*
+for dataset in ${DATADIR}/${DATASET}*
 do
     echo "executing with dataset ${dataset}"
     inputs=`ls ${dataset}/input* 2>/dev/null | xargs echo | sed -e "s/  */,/g"`


### PR DESCRIPTION
Added support for running `runmp.sh` in 2 ways:

* `runmp.sh 1`: same as before, runs `MP1` on all datasets
* `runmp.sh 1 0`: runs `MP1` only on dataset 0, useful for debugging purposes.