### PR TITLE
Clock gettime not present in Apple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ if (UNIX AND NOT APPLE)
     if(NOT HAVE_CLOCK_GETTIME)
         message(FATAL_ERROR "clock_gettime not found")
     endif(NOT HAVE_CLOCK_GETTIME)
-endif(UNIX)
+endif(UNIX AND NOT APPLE)
  
 file( GLOB  wbhdr *.hpp *.h )
 file( GLOB  wbsrc *.cpp *.c )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ else(CUDA_FOUND)
     message("CUDA is not installed on this system.")
 endif()
  
-if (UNIX)
+if (UNIX AND NOT APPLE)
     include(CheckLibraryExists)
     check_library_exists(rt clock_gettime "time.h" HAVE_CLOCK_GETTIME )
     if(NOT HAVE_CLOCK_GETTIME)


### PR DESCRIPTION
I could not compile in os x due to the absence of clock_gettime. It turns out that in wbTime.cpp, this was already accounted for. It was just the check in CMakeLists.txt that kept it from compiling, so I make APPLE an exclusion for that check.