### PR TITLE
Use version-agnostic path for CUDA headers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 ##########################################
 CXX=g++
 DEFINES=-DWB_USE_CUDA
-CUDA_INCLUDE=/usr/local/cuda-5.5/include
+CUDA_INCLUDE=/usr/local/cuda/include
 CXX_FLAGS=-fPIC -x c++ -O0 -g -I . -I $(CUDA_INCLUDE) -L $(HOME)/usr/lib -Wall  -I$(HOME)/usr/include $(DEFINES)
 LIBS=-lm -lstdc++ -lrt -lcuda -L$(HOME)/usr/lib
 ARCH=$(shell uname -s)-$(shell uname -i)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require 'English'
+
+task :default do
+    system "make"
+    fail "Make failed." unless $CHILD_STATUS.exitstatus == 0
+end


### PR DESCRIPTION
Set the Makefile to include headers from the version-agnostic symlink at
/usr/local/cuda/include. Allows compilation with CUDA 6.5 installed.