### PR TITLE
CMakeLists: Remove redundant statements / settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,12 @@ find_package(CUDA REQUIRED)
 include_directories(${PROJECT_SOURCE_DIR})
 
 # For some MPs it may be necessary to specify the compute capability of your
-# nVidia GPU. In that case, simply uncomment the following two lines that start
+# NVIDIA GPU. In that case, simply uncomment the following two lines that start
 # with 'set' and change the value of COMPUTE_CAPABILITY to one of the following
-# hardware architectures: Tesla-class 11, 12, or 13; Fermi-class 20 or 21;
-# Kepler-class 30, 32, or 35; or Maxwell-class 50 or 52
+# hardware architectures: Tesla-class '11', '12', or '13'; Fermi-class '20'
+# or '21'; Kepler-class '30', '32', '35'; or Maxwell-class '50' or '52'
 # set(COMPUTE_CAPABILITY 35)
-# set(CUDA_NVCC_FLAGS --generate-code;arch=compute_${COMPUTE_CAPABILITY},code=sm_${COMPUTE_CAPABILITY})
+# set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};--gpu-architecture;sm_${COMPUTE_CAPABILITY})
 
 # Set warning levels for host compilation
 if (UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ if (APPLE)
     endif ()
 endif ()
 
-
 # Add debugging to CUDA NVCC flags (for NVidia's NSight tools)
 set(CUDA_NVCC_FLAGS_DEBUG ${CUDA_NVCC_FLAGS_DEBUG} "-G")
 
@@ -65,34 +64,10 @@ if (UNIX)
     endif ()
 endif ()
 
-if(CUDA_FOUND)
-    # compared to class settings, we let NVidia's FindCUDA CMake detect 
-    # whether to build x64.  We tell it to support most devices, though, 
-    # to make sure more people can easily run class code without knowing 
-    # about this compiler argument
-    set(CUDA_NVCC_FLAGS "")
- 
-    # add -Wextra compiler flag for gcc compilations
-    if (UNIX)
-        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} "-Xcompiler -Wall;")
-        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} "-Xcompiler -Wextra")
-    endif (UNIX)
- 
-    # add debugging to CUDA NVCC flags.  For NVidia's NSight tools.
-    set(CUDA_NVCC_FLAGS_DEBUG ${CUDA_NVCC_FLAGS_DEBUG} "-G")
-    include_directories(${CMAKE_SOURCE_DIR})
-    include_directories(${CUDA_INCLUDE_DIRS})
-else(CUDA_FOUND)
-    message("CUDA is not installed on this system.")
-endif()
-
 # Collect source files
 file(GLOB WBHDR *.hpp *.h)
 file(GLOB WBSRC *.cpp *.c)
- 
-include_directories(${CMAKE_SOURCE_DIR})
-include_directories(${CUDA_INCLUDE_DIRS})
- 
+
 set(EXECUTABLES mp0 mp1 mp2 mp3 mp4 mp5 mp6 mp11 mp12)
 foreach (EXECUTABLE ${EXECUTABLES})
     string(TOUPPER "${EXECUTABLE}" LABEL)


### PR DESCRIPTION
This reverses changes introduced by the following commit:

abduld/libwb@9304d416c7290da49066e960eb801ef4964d7522

Reason:

* The `REQUIRED` option to `find_package()` will stop processing and present a warning message if a CUDA installation cannot be found. This makes the use of a `if (CUDA_FOUND)` guard redundant.

* Setting `CUDA_NVCC_FLAGS` to `""` (on line 73) will clear any previously set options (in this case it will invalidate the setting of a device's `COMPUTE_CAPABILITY` on lines 18-19).

* The following code repeats the warning options already set via `CMAKE_CXX_FLAGS` (on line 23). `nvcc` will automatically propagate these settings for you to the host compiler.
```cmake
if (UNIX)
    set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} "-Xcompiler -Wall;")
    set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} "-Xcompiler -Wextra")
endif (UNIX)
```

* Line 82, `set(CUDA_NVCC_FLAGS_DEBUG ${CUDA_NVCC_FLAGS_DEBUG} "-G")` repeats line 47.

* Lines 83-84 repeat lines 93-94.

* Line 93, `include_directories(${CMAKE_SOURCE_DIR})` repeats line 11.

* Line 94 is redundant as `CUDA_INCLUDE_DIRS` is added automatically for you by `CUDA_ADD_EXECUTABLE()`

The second commit lets `nvcc` set the appropriate virtual architecture based on the user's specified real architecture. This prevents an error if compute capability `21` is selected (this is the only 'real' architecture that isn't backed by a matching 'virtual' architecture of the same capability).