### PR TITLE
More readable errors for image mismatch

### DIFF
--- a/wbImage.cpp
+++ b/wbImage.cpp
@@ -108,8 +108,8 @@ wbBool wbImage_sameQ(wbImage_t a, wbImage_t b,
           if (wbUnequalQ(x, y)) {
             if (onUnSame != NULL) {
               string str = wbString("Image pixels do not match at position (",
-                                    wbString(ii, ", ", jj, ", ", kk, "). [ "),
-                                    wbString(x, ", ", y, "]"));
+                                    wbString("x=", ii, ", y=", jj, ", channel=", kk, "). "),
+                                    wbString("Got ", x, ", expected ", y));
               onUnSame(str);
             }
             return wbFalse;


### PR DESCRIPTION
Before:

	Image pixels do not match at position (0, 0, 0). [0, 0.439216]

After:

	Image pixels do not match at position (x=0, y=0, channel=0). Got 0, expected 0.439216