### PR TITLE
Don't warn about unused functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ include_directories(${PROJECT_SOURCE_DIR})
 
 # Set warning levels for host compilation
 if (UNIX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-function -Wextra")
 endif ()
 
 # Select the correct host compiler on OS X


### PR DESCRIPTION
In the normal compilation of the wb.h header, a lot of functions are provided
but will not be used. That could be fixed, but in the meantime, we can ignore
all the unused-function warnings. This will make the real warnings visible.