### PR TITLE
Fixed grayscale output files

### DIFF
--- a/wbExport.cpp
+++ b/wbExport.cpp
@@ -385,7 +385,8 @@ static wbExportKind_t _parseExportExtension(const char *file) {
   } else if (wbString_sameQ(extension, "text") ||
              wbString_sameQ(extension, "txt")) {
     kind = wbExportKind_text;
-  } else if (wbString_sameQ(extension, "ppm")) {
+  } else if (wbString_sameQ(extension, "ppm") ||
+             wbString_sameQ(extension, "pbm")) {
     kind = wbExportKind_ppm;
   } else {
     kind = wbExportKind_unknown;

--- a/wbSolution.cpp
+++ b/wbSolution.cpp
@@ -174,7 +174,7 @@ wbBool wbSolution(char *expectedOutputFile, char *outputFile, char *type0,
                                   wbImage_getHeight(inputImage),
                                   wbImage_getChannels(inputImage));
       memcpy(wbImage_getData(img), wbImage_getData(inputImage),
-             rows * columns * wbImage_channels * sizeof(wbReal_t));
+             rows * columns * depth * sizeof(wbReal_t));
       wbExport(outputFile, img);
       wbImage_delete(img);
     } else if (wbString_sameQ(type, "integral_vector/sort")) {


### PR DESCRIPTION
The code for outputting an image file previously used a constant that assumed three channels, this would break with an out of bounds access when only one channel was being used (grayscale). Also, another check needed to be added to accept "pbm" as a valid extension for an output file.